### PR TITLE
member fix (#23)

### DIFF
--- a/server/src/main/java/com/alioth/server/common/init/DataInitialization.java
+++ b/server/src/main/java/com/alioth/server/common/init/DataInitialization.java
@@ -28,7 +28,7 @@ public class DataInitialization implements CommandLineRunner {
         if(memberList.size() == 0) {
             SalesMemberCreateReqDto fpDto = SalesMemberCreateReqDto.builder()
                     .email("jangdg@naver.com") // 마스킹
-                    .phone("010-1234-1234") // 끝 4자리 마스킹
+                    .phone("010-1234-0001") // 끝 4자리 마스킹
                     .name("장동건")
                     .password("a1234567!")
                     .birthDay("990123") // 마스킹
@@ -38,7 +38,7 @@ public class DataInitialization implements CommandLineRunner {
 
             SalesMemberCreateReqDto managerDto = SalesMemberCreateReqDto.builder()
                     .email("wonb@naver.com") // 마스킹
-                    .phone("010-1234-1234") // 끝 4자리 마스킹
+                    .phone("010-1234-0002") // 끝 4자리 마스킹
                     .name("원빈")
                     .password("a1234567!")
                     .birthDay("990123") // 마스킹
@@ -48,7 +48,7 @@ public class DataInitialization implements CommandLineRunner {
 
             SalesMemberCreateReqDto hqDto = SalesMemberCreateReqDto.builder()
                     .email("gosoo@naver.com") // 마스킹
-                    .phone("010-1234-1234") // 끝 4자리 마스킹
+                    .phone("010-1234-0003") // 끝 4자리 마스킹
                     .name("고수")
                     .password("a1234567!")
                     .birthDay("990123") // 마스킹

--- a/server/src/main/java/com/alioth/server/common/jwt/JwtAuthFilter.java
+++ b/server/src/main/java/com/alioth/server/common/jwt/JwtAuthFilter.java
@@ -45,7 +45,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 }
             }
         } catch (ExpiredJwtException e) {
-            //reissueAccessToken(request, response, e);
             String accessToken = parseBearerToken(request);
             String name = jwtTokenProvider.decodeJwtPayloadSubject(accessToken).split(":")[0];
             String reqRefreshToken = parseBearerTokenRefresh(request);

--- a/server/src/main/java/com/alioth/server/domain/member/domain/SalesMembers.java
+++ b/server/src/main/java/com/alioth/server/domain/member/domain/SalesMembers.java
@@ -28,19 +28,19 @@ public class SalesMembers extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 19)
     private String phone;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 18)
     private String name;
 
-    @Column(nullable = false, length = 8)
+    @Column(nullable = false, length = 64)
     private String password;
 
     @Column(nullable = false)
     private String birthDay;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 200)
     private String address;
 
     @Column


### PR DESCRIPTION
* [feat]: 초기 데이터 생성
- 스프링 시작하면 DB의 sales_members 테이블을 확인
- 값이 아무것도 없으면 FP, MANAGER, HQ 권한을 가진 맴버 3명 생성

* [feat]: hotfix
- SalesMembers 엔티티 패스워드 길이 수정
- SalesMembers 엔티티 휴대폰 길이 수정
- SalesMembers 엔티티 주소 길이 수정
- SalesMembers 엔티티 이름 길이 수정
- 초기생성 데이터 기본값 수정

---------